### PR TITLE
Table size changed

### DIFF
--- a/webapp/styles/pokemon-table.component.css
+++ b/webapp/styles/pokemon-table.component.css
@@ -9,8 +9,8 @@ table#stats-as-table thead tr{
 
 table#stats-as-table tbody{
 	display: block;
-	overflow: auto;
-	height: 400px;
+	overflow-y: scroll;
+	height: 600px;
 }
 
 


### PR DESCRIPTION
Table was heightened from 400px to 600px and made to only scroll vertically. Discussed in https://github.com/Eric-Carlton/PokemonGoReader/issues/36
