### PR TITLE
Changed syntax decls from 'let' to 'var' to improve compatibility

### DIFF
--- a/server/utils/pokemonUtils.js
+++ b/server/utils/pokemonUtils.js
@@ -31,8 +31,8 @@ module.exports = {
 	},
 
 	getCandy: (pokemon, candies) => {
-		for(let j = 0; j < candies.length; j++){
-			let candy = candies[j];
+		for(var j = 0; j < candies.length; j++){
+			var candy = candies[j];
 
 			if(candy.family_id.toString() === props.pokemonFamilyIdByPokedexNum[pokemon.pokemon_id.toString()]){
 				return candy.candy;


### PR DESCRIPTION
I was having an issue running `npm start` on my Ubuntu server running nodejs 4.4.7 without the following changes.

```
[0]
[0] > ivreader@0.0.1 server /home/csmith/projects/PokemonGoReader
[0] > node server/index.js | node node_modules/bunyan/bin/bunyan
[0]
[1]
[1] > ivreader@0.0.1 webapp /home/csmith/projects/PokemonGoReader
[1] > npm run clean && tsc --outDir ./webapp/js && node ./node_modules/http-server/bin/http-server
[1]
[1]
[1] > ivreader@0.0.1 clean /home/csmith/projects/PokemonGoReader
[1] > node ./node_modules/rimraf/bin.js ./webapp/js/*
[1]
[0] /home/csmith/projects/PokemonGoReader/server/utils/pokemonUtils.js:34
[0]             for(let j = 0; j < candies.length; j++){
[0]                 ^^^
[0]
[0] SyntaxError: Block-scoped declarations (let, const, function, class) not yet supported outside strict mode
[0]     at exports.runInThisContext (vm.js:53:16)
[0]     at Module._compile (module.js:373:25)
[0]     at Object.Module._extensions..js (module.js:416:10)
[0]     at Module.load (module.js:343:32)
[0]     at Function.Module._load (module.js:300:12)
[0]     at Module.require (module.js:353:17)
[0]     at require (internal/module.js:12:17)
[0]     at Object.<anonymous> (/home/csmith/projects/PokemonGoReader/server/routes/pokemonRoutes.js:9:22)
[0]     at Module._compile (module.js:409:26)
[0]     at Object.Module._extensions..js (module.js:416:10)
[0]     at Module.load (module.js:343:32)
[0]     at Function.Module._load (module.js:300:12)
[0]     at Module.require (module.js:353:17)
[0]     at require (internal/module.js:12:17)
[0]     at Object.<anonymous> (/home/csmith/projects/PokemonGoReader/server/index.js:8:23)
[0]     at Module._compile (module.js:409:26)
[0] npm run server exited with code 0
[1] Starting up http-server, serving ./
[1] Available on:
[1]   http://127.0.0.1:8081
[1]   http://192.168.0.66:8081
[1] Hit CTRL-C to stop the server
```
